### PR TITLE
Swallow exceptions (LT-19036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Swallow exceptions and return false (https://jira.sil.org/browse/LT-19036)
+
 ## [1.1.0] - 2021-04-26
 
 ### Changed

--- a/IPCFramework/WindowsIPCClient.cs
+++ b/IPCFramework/WindowsIPCClient.cs
@@ -40,7 +40,7 @@ namespace IPCFramework
 			{
 				Console.WriteLine("WindowsIPCClient.Initialize(\"{0}\") caught exception: {1}",
 					connectionId, ex.Message);
-				throw;
+				return false;
 			}
 		}
 
@@ -54,29 +54,14 @@ namespace IPCFramework
 			try
 			{
 				var mi = _clientType.GetMethod(rpcMethod);
-				if (mi != null)
-				{
-					try
-					{
-						mi.Invoke(_channel, args);
-					}
-					catch (TargetInvocationException e)
-					{
-						// A dropped connection means we cannot call the other end. Return false, but don't throw.
-						if (e.InnerException is EndpointNotFoundException)
-							return false;
-						throw; //other reasons for failing are exceptional
-					}
-				}
+				mi?.Invoke(_channel, args);
 				return true;
 			}
 			catch (Exception ex)
 			{
 				Console.WriteLine("WindowsIPCClient.RemoteCall(\"{0}\") caught exception: {1}",
 					rpcMethod, ex.Message);
-				if (rpcMethod == "BridgeWorkComplete")
-					return false;
-				throw;
+				return false;
 			}
 		}
 
@@ -95,7 +80,7 @@ namespace IPCFramework
 			{
 				Console.WriteLine("WindowsIPCClient.RemoteCall(\"{0}\") caught exception: {1}",
 					rpcMethod, ex.Message);
-				throw;
+				return false;
 			}
 		}
 


### PR DESCRIPTION
Swallow client exceptions. Unix already does. Windows users get strange errors at unpredictable times, since
https://github.com/sillsdev/flexbridge takes 15 seconds to quit after all windows are closed, and
https://github.com/sillsdev/fieldworks may already be closed anyway.

Addresses https://jira.sil.org/browse/LT-19036 and several others.